### PR TITLE
Switch to karma-phantomjs2-launcher

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,7 +14,7 @@ module.exports = function(config) {
 
     plugins: [
       'karma-chrome-launcher',
-      'karma-phantomjs-launcher',
+      'karma-phantomjs2-launcher',
       'karma-jquery',
       'karma-jasmine',
       'karma-spec-reporter'
@@ -67,7 +67,7 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['PhantomJS'],
+    browsers: ['PhantomJS2'],
 
 
     // Continuous Integration mode

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "karma-chrome-launcher": "^0.1.4",
     "karma-jasmine": "^0.3.6",
     "karma-jquery": "^0.1.0",
-    "karma-phantomjs-launcher": "^0.1.4",
+    "karma-phantomjs2-launcher": "^0.4.0",
     "karma-spec-reporter": "^0.0.18",
     "run-sequence": "^1.0.2"
   },


### PR DESCRIPTION
PhantomJS 1 is fails to load in angular 1.5+
due to missing function prototypes.

Can revert to karma-phantomjs-launcher
once it officially supports PhantomJS2

No fix from the angular project because phantomjs
is not one of the officially supported browsers

See:
https://github.com/angular/angular.js/issues/13794
